### PR TITLE
Check canceled context so Listen can return

### DIFF
--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"google3/third_party/golang/grpctunnel/tunnel/tunnel"
+	"github.com/openconfig/grpctunnel/tunnel"
 )
 
 func TestListen(t *testing.T) {


### PR DESCRIPTION
A call to Listen does not return unless a connection with a grpctunnel server is established. As a result, it is not possible to stop the client from dialing out. It would be ideal to be able to return from Listen with context.CancelFunc.
- Add a canceled context check.
- Make the backoff sleep non-blocking so it's possible to return from a canceled context during the backoff wait.