### PR TITLE
Close listener to prevent dial out during backoff wait

### DIFF
--- a/cmd/server/server_test.go
+++ b/cmd/server/server_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"testing"
 
-	"google3/third_party/golang/grpctunnel/tunnel/tunnel"
+	"github.com/openconfig/grpctunnel/tunnel"
 )
 
 func TestListen(t *testing.T) {

--- a/tunnel/conn.go
+++ b/tunnel/conn.go
@@ -196,6 +196,9 @@ func Listen(ctx context.Context, addr string, cert string, targets map[Target]st
 			}()
 			return l, nil
 		}
+		if err := l.Close(); err != nil {
+			log.Printf("%v", err)
+		}
 
 		// tunnel client establishes a tunnel session if it succeeded.
 		// retry if it fails.


### PR DESCRIPTION
The client continues to dial out during the backoff wait (as grpc.Dial is non-blocking). Close the listener after registerTunnelClient if the tunnel registration fails.